### PR TITLE
Fix: Path to php-cs-fixer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ coverage: vendor ## Collects coverage from running unit tests with phpunit
 
 cs: vendor ## Fixes code style issues with php-cs-fixer
 	mkdir -p .build/php-cs-fixer
-	tools/php-cs-fixer fix --config=.php_cs --diff --verbose
+	vendor/bin/php-cs-fixer fix --config=.php_cs --diff --verbose
 
 help: ## Displays this list of targets with descriptions
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[32m%-30s\033[0m %s\n", $$1, $$2}'


### PR DESCRIPTION
This PR

* [x] fixes the path to `php-cs-fixer` as referenced in `Makefile`