### PR TITLE
Fix: reference workflow

### DIFF
--- a/.github/workflows/reference.yml
+++ b/.github/workflows/reference.yml
@@ -14,11 +14,11 @@ jobs:
 
     steps:
       - name: "Is branch"
-        if: "startsWith(github.event.ref, 'refs/heads/')"
+        if: "startsWith(github.ref, 'refs/heads/')"
         run: echo "Is branch"
 
       - name: "Is master"
-        if: "github.event.name == 'push' && github.event.ref == 'refs/heads/master'"
+        if: "github.event_name == 'push' && github.ref == 'refs/heads/master'"
         run: echo "Is master"
 
       - name: "Is pull request"


### PR DESCRIPTION
The "Is master" step wasn't working.

Is there any difference between `github.event.ref` and `github.ref`?

