### PR TITLE
Fix: Remove default reviewers configuration

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -10,8 +10,6 @@ update_configs:
       - "localheinz"
     default_labels:
       - "dependency"
-    default_reviewers:
-      - "localheinz"
     directory: "/"
     package_manager: "php:composer"
     update_schedule: "live"


### PR DESCRIPTION
This PR

* [x] removes the default reviewers configuration for Dependabot