### PR TITLE
Fix: Do not assign @localheinz by default

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 *               @localheinz
-composer.json   @ergebnis-bot @localheinz
-composer.lock   @ergebnis-bot @localheinz
+composer.json   @ergebnis-bot
+composer.lock   @ergebnis-bot

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -28,6 +28,7 @@ branches:
           - "Tests (7.4, highest)"
           - "Code Coverage (7.4, locked)"
           - "Mutation Tests (7.4, locked)"
+          - "Approve"
           - "codecov/patch"
           - "codecov/project"
         strict: false

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -349,3 +349,29 @@ jobs:
         if: "(github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]') && github.event_name == 'pull_request' && startsWith(github.event.pull_request.title, 'Build(deps-dev)')"
         with:
           github-token: "${{ secrets.ERGEBNIS_BOT_TOKEN }}"
+
+      - name: "Request review from @localheinz when necessary"
+        uses: "actions/github-script@0.4.0"
+        if: "(github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]') && github.event_name == 'pull_request' && !startsWith(github.event.pull_request.title, 'Build(deps-dev)')"
+        with:
+          github-token: "${{ secrets.ERGEBNIS_BOT_TOKEN }}"
+          script: |
+            const options = {
+              owner: context.owner,
+              repo: context.repo,
+              pull_number: context.event.number
+            }
+
+            github.pulls.deleteReviewRequest({
+              ...options,
+              reviewers: [
+                'ergebnis-bot'
+              ]
+            })
+
+            github.pulls.createReviewRequest({
+              ...options,
+              reviewers: [
+                'localheinz'
+              ]
+            })


### PR DESCRIPTION
This PR

* [x] removes @localheinz from `CODEOWNERS` for `composer.json` and `composer.lock` and only requests reviews when necessary