### PR TITLE
Fix: Do not create deployment when pull request is opened

### DIFF
--- a/.github/workflows/deployment-staging-create.yaml
+++ b/.github/workflows/deployment-staging-create.yaml
@@ -6,7 +6,6 @@ on: # yamllint disable-line rule:truthy
   pull_request:
     types:
       - "labeled"
-      - "opened"
       - "reopened"
       - "synchronize"
 
@@ -16,7 +15,7 @@ jobs:
 
     runs-on: "ubuntu-latest"
 
-    if: "((github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'synchronize') && contains(github.event.pull_request.labels.*.name, 'environment')) || (github.event.action == 'labeled' &&  github.event.label.name == 'environment')"
+    if: "((github.event.action == 'reopened' || github.event.action == 'synchronize') && contains(github.event.pull_request.labels.*.name, 'environment')) || (github.event.action == 'labeled' &&  github.event.label.name == 'environment')"
 
     steps:
       - name: "Checkout"


### PR DESCRIPTION
This PR

* [x] do not create deployment when pull request is opened

💁‍♂ When a pull request is opened with a label, both the `opened` and `labeled` events will be triggered.