### PR TITLE
Fix: Always provide log URL when creating deployment status

### DIFF
--- a/.github/workflows/deployment-process.yaml
+++ b/.github/workflows/deployment-process.yaml
@@ -41,6 +41,7 @@ jobs:
           script: |
             github.repos.createDeploymentStatus({
               deployment_id: context.payload.deployment.id,
+              log_url: "https://github.com/" + context.repo.owner + "/" + context.repo.repo + "/commit/" + context.payload.deployment.sha + "/checks",
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: "failure"
@@ -60,6 +61,7 @@ jobs:
             github.repos.createDeploymentStatus({
               deployment_id: currentDeployment.id,
               environment_url: currentDeployment.payload.environmentUrl,
+              log_url: "https://github.com/" + context.repo.owner + "/" + context.repo.repo + "/commit/" + context.payload.deployment.sha + "/checks",
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: "success"


### PR DESCRIPTION
This PR

* [x] always provides the `log_url` attribute when creating a deployment status