### PR TITLE
Fix: Provide log URL when deployment is marked as inactive

### DIFF
--- a/.github/workflows/deployment-process.yaml
+++ b/.github/workflows/deployment-process.yaml
@@ -89,6 +89,7 @@ jobs:
 
               github.repos.createDeploymentStatus({
                 deployment_id: deployment.id,
+                log_url: "https://github.com/" + context.repo.owner + "/" + context.repo.repo + "/commit/" + deployment.sha + "/checks",
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 state: "inactive"


### PR DESCRIPTION
This PR

* [x] provides the log URL when a deployment is marked as inactive