### PR TITLE
Fix: Provide log URL when deployment is marked as inactive

### DIFF
--- a/.github/workflows/deployment-staging-delete.yaml
+++ b/.github/workflows/deployment-staging-delete.yaml
@@ -34,6 +34,7 @@ jobs:
             deployments.forEach(deployment => {
               github.repos.createDeploymentStatus({
                 deployment_id: deployment.id,
+                log_url: `https://github.com/${repository.owner}/${repository.repo}/commit/${deployment.sha}/checks`,
                 owner: repository.owner,
                 repo: repository.repo,
                 state: "inactive"


### PR DESCRIPTION
This PR

* [x] provides a log URL when staging deployment is marked as inactive